### PR TITLE
Update for latest syntax

### DIFF
--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -32,8 +32,8 @@ using HDF5, MAT_HDF5, MAT_v5
 export matopen, matread, matwrite, names, exists, @read, @write
 
 # Open a MATLAB file
-const HDF5_HEADER = Uint8[0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a]
-function matopen(filename::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::Bool)
+const HDF5_HEADER = UInt8[0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a]
+function matopen(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::Bool)
     # When creating new files, create as HDF5 by default
     fs = filesize(filename)
     if cr && (tr || fs == 0)
@@ -49,7 +49,7 @@ function matopen(filename::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::B
     rawfid = open(filename, "r")
 
     # Check for MAT v4 file
-    magic = read(rawfid, Uint8, 4)
+    magic = read(rawfid, UInt8, 4)
     for i = 1:length(magic)
         if magic[i] == 0
             close(rawfid)
@@ -59,8 +59,8 @@ function matopen(filename::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::B
 
     # Check for MAT v5 file
     seek(rawfid, 124)
-    version = read(rawfid, Uint16)
-    endian_indicator = read(rawfid, Uint16)
+    version = read(rawfid, UInt16)
+    endian_indicator = read(rawfid, UInt16)
     if (version == 0x0100 && endian_indicator == 0x4D49) ||
        (version == 0x0001 && endian_indicator == 0x494D)
         if wr || cr || tr || ff
@@ -72,7 +72,7 @@ function matopen(filename::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::B
     # Check for HDF5 file
     for offset = 512:512:fs-8
         seek(rawfid, offset)
-        if read(rawfid, Uint8, 8) == HDF5_HEADER
+        if read(rawfid, UInt8, 8) == HDF5_HEADER
             close(rawfid)
             return MAT_HDF5.matopen(filename, rd, wr, cr, tr, ff)
         end
@@ -82,7 +82,7 @@ function matopen(filename::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::B
     error("\"$filename\" is not a MAT file")
 end
 
-function matopen(fname::String, mode::String)
+function matopen(fname::AbstractString, mode::AbstractString)
     mode == "r"  ? matopen(fname, true , false, false, false, false) :
     mode == "r+" ? matopen(fname, true , true , false, false, false) :
     mode == "w"  ? matopen(fname, false, true , true , true , false) :
@@ -92,7 +92,7 @@ function matopen(fname::String, mode::String)
     error("invalid open mode: ", mode)
 end
 
-matopen(fname::String) = matopen(fname, "r")
+matopen(fname::AbstractString) = matopen(fname, "r")
 
 function matopen(f::Function, args...)
     fid = matopen(args...)
@@ -104,7 +104,7 @@ function matopen(f::Function, args...)
 end
 
 # Read all variables from a MATLAB file
-function matread(filename::String)
+function matread(filename::AbstractString)
     file = matopen(filename)
     local vars
     try
@@ -116,7 +116,7 @@ function matread(filename::String)
 end
 
 # Write a dict to a MATLAB file
-function matwrite{S, T}(filename::String, dict::Dict{S, T})
+function matwrite{S, T}(filename::AbstractString, dict::Dict{S, T})
     file = matopen(filename, "w")
     try
         for (k, v) in dict

--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -27,7 +27,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 include("MAT_HDF5.jl")
 include("MAT_v5.jl")
 module MAT
-using HDF5, MAT_HDF5, MAT_v5
+using HDF5, MAT_HDF5, MAT_v5, Compat
 
 export matopen, matread, matwrite, names, exists, @read, @write
 

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -32,6 +32,9 @@ using HDF5, Compat
 import Base: read, write, close
 import HDF5: names, exists, HDF5ReferenceObj, HDF5BitsKind
 
+typealias HDF5Parent @compat(Union{HDF5File, HDF5Group})
+typealias HDF5BitsOrBool @compat(Union{HDF5BitsKind,Bool})
+
 type MatlabHDF5File <: HDF5.DataFile
     plain::HDF5File
     toclose::Bool
@@ -135,7 +138,7 @@ function m_read(dset::HDF5Dataset)
         if mattype == "char"
             return ""
         else
-            T = mattype == "canonical empty" ? Union{} : str2eltype_matlab[mattype]
+            T = mattype == "canonical empty" ? @compat(Union{}) : str2eltype_matlab[mattype]
             return Array(T, dims...)
         end
     end
@@ -278,7 +281,7 @@ function m_writetypeattr(dset, T)
 end
 
 # Writes an empty scalar or array
-function m_writeempty(parent::Union{HDF5File, HDF5Group}, name::ByteString, data::Array)
+function m_writeempty(parent::HDF5Parent, name::ByteString, data::Array)
     adata = [size(data)...]
     dset, dtype = d_create(parent, name, adata)
     try
@@ -292,7 +295,7 @@ function m_writeempty(parent::Union{HDF5File, HDF5Group}, name::ByteString, data
 end
 
 # Write an array to a dataset in a MATLAB file, returning the dataset
-function m_writearray{T<:Union{HDF5BitsKind,Bool}}(parent::Union{HDF5File, HDF5Group}, name::ByteString, adata::Array{T})
+function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::ByteString, adata::Array{T})
     dset, dtype = d_create(parent, name, adata)
     try
         HDF5.writearray(dset, dtype.id, adata)
@@ -304,7 +307,7 @@ function m_writearray{T<:Union{HDF5BitsKind,Bool}}(parent::Union{HDF5File, HDF5G
         close(dtype)
     end
 end
-function m_writearray{T<:Union{HDF5BitsKind,Bool}}(parent::Union{HDF5File, HDF5Group}, name::ByteString, adata::Array{Complex{T}})
+function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::ByteString, adata::Array{Complex{T}})
     dtype = build_datatype_complex(T)
     try
         stype = dataspace(adata)
@@ -326,7 +329,7 @@ function m_writearray{T<:Union{HDF5BitsKind,Bool}}(parent::Union{HDF5File, HDF5G
 end
 
 # Write a scalar or array
-function m_write{T<:Union{HDF5BitsKind,Bool}}(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name::ByteString, data::Union{T, Complex{T}, Array{T}, Array{Complex{T}}})
+function m_write{T<:HDF5BitsOrBool}(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, data::@compat(Union{T, Complex{T}, Array{T}, Array{Complex{T}}}))
     if isempty(data)
         m_writeempty(parent, name, data)
         return
@@ -340,7 +343,7 @@ function m_write{T<:Union{HDF5BitsKind,Bool}}(mfile::MatlabHDF5File, parent::Uni
 end
 
 # Write sparse arrays
-function m_write{T}(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name::ByteString, data::SparseMatrixCSC{T})
+function m_write{T}(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, data::SparseMatrixCSC{T})
     g = g_create(parent, name)
     try
         m_writetypeattr(g, T)
@@ -356,7 +359,7 @@ function m_write{T}(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, n
 end
 
 # Write a string
-function m_write(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name::ByteString, str::AbstractString)
+function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, str::AbstractString)
     if isempty(str)
         data = UInt64[0, 0]
 
@@ -393,7 +396,7 @@ function m_write(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name
 end
 
 # Write cell arrays
-function m_write{T}(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name::ByteString, data::Array{T})
+function m_write{T}(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, data::Array{T})
     pathrefs = "/#refs#"
     fid = file(parent)
     local g
@@ -463,7 +466,7 @@ function check_struct_keys(k::Vector)
 end
 
 # Write a struct from arrays of keys and values
-function m_write(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name::ByteString, k::Vector{ASCIIString}, v::Vector)
+function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, k::Vector{ASCIIString}, v::Vector)
     g = g_create(parent, name)
     a_write(g, name_type_attr_matlab, "struct")
     for i = 1:length(k)
@@ -473,11 +476,11 @@ function m_write(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name
 end
 
 # Write Associative as a struct
-m_write(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name::ByteString, s::Associative) =
+m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, s::Associative) =
     m_write(mfile, parent, name, check_struct_keys(collect(keys(s))), collect(values(s)))
 
 # Write generic CompositeKind as a struct
-function m_write(mfile::MatlabHDF5File, parent::Union{HDF5File, HDF5Group}, name::ByteString, s)
+function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, s)
     if isbits(s)
         error("This is the write function for CompositeKind, but the input doesn't fit")
     end

--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -68,14 +68,14 @@ const mxINT32_CLASS = 12
 const mxUINT32_CLASS = 13
 const mxINT64_CLASS = 14
 const mxUINT64_CLASS = 15
-const READ_TYPES = Type[Int8, UInt8, Int16, UInt16, Int32, UInt32, Float32, None, Float64,
-    None, None, Int64, UInt64]
-const CONVERT_TYPES = Type[None, None, None, None, None, Float64, Float32, Int8, UInt8,
+const READ_TYPES = Type[Int8, UInt8, Int16, UInt16, Int32, UInt32, Float32, Union{}, Float64,
+    Union{}, Union{}, Int64, UInt64]
+const CONVERT_TYPES = Type[Union{}, Union{}, Union{}, Union{}, Union{}, Float64, Float32, Int8, UInt8,
     Int16, UInt16, Int32, UInt32, Int64, UInt64]
 
 read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}) = 
     swap_bytes ? bswap(read(f, T)) : read(f, T)
-function read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}, dim::Union(Int, @compat Tuple{Vararg{Int}}))
+function read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}, dim::Union{Int, @compat Tuple{Vararg{Int}}})
     d = read(f, T, dim)
     if swap_bytes
         for i = 1:length(d)
@@ -158,7 +158,7 @@ function read_struct(f::IO, swap_bytes::Bool, dimensions::Vector{Int32}, is_obje
 
 
     # Get field names as strings
-    field_name_strings = Array(String, n_fields)
+    field_name_strings = Array(ASCIIString, n_fields)
     n_el = prod(dimensions)
     for i = 1:n_fields
         sname = field_names[(i-1)*field_length+1:i*field_length]
@@ -304,7 +304,7 @@ function read_matrix(f::IO, swap_bytes::Bool)
         #     a = {[], [], []}
         # then MATLAB does not save the empty cells as zero-byte matrices. To avoid
         # surprises, we produce an empty array in both cases.
-        return ("", Array(None, 0, 0))
+        return ("", Array(Union{}, 0, 0))
     end
 
     flags = read_element(f, swap_bytes, UInt32)

--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -68,14 +68,17 @@ const mxINT32_CLASS = 12
 const mxUINT32_CLASS = 13
 const mxINT64_CLASS = 14
 const mxUINT64_CLASS = 15
-const READ_TYPES = Type[Int8, UInt8, Int16, UInt16, Int32, UInt32, Float32, Union{}, Float64,
-    Union{}, Union{}, Int64, UInt64]
-const CONVERT_TYPES = Type[Union{}, Union{}, Union{}, Union{}, Union{}, Float64, Float32, Int8, UInt8,
+const READ_TYPES = Type[
+    Int8, UInt8, Int16, UInt16, Int32, UInt32, Float32, @compat(Union{}),
+    Float64, @compat(Union{}), @compat(Union{}), Int64, UInt64]
+const CONVERT_TYPES = Type[
+    @compat(Union{}), @compat(Union{}), @compat(Union{}), @compat(Union{}),
+    @compat(Union{}), Float64, Float32, Int8, UInt8,
     Int16, UInt16, Int32, UInt32, Int64, UInt64]
 
 read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}) = 
     swap_bytes ? bswap(read(f, T)) : read(f, T)
-function read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}, dim::Union{Int, @compat Tuple{Vararg{Int}}})
+function read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}, dim::@compat(Union{Int, @compat Tuple{Vararg{Int}}}))
     d = read(f, T, dim)
     if swap_bytes
         for i = 1:length(d)
@@ -304,7 +307,7 @@ function read_matrix(f::IO, swap_bytes::Bool)
         #     a = {[], [], []}
         # then MATLAB does not save the empty cells as zero-byte matrices. To avoid
         # surprises, we produce an empty array in both cases.
-        return ("", Array(Union{}, 0, 0))
+        return ("", Array(@compat(Union{}), 0, 0))
     end
 
     flags = read_element(f, swap_bytes, UInt32)

--- a/test/write.jl
+++ b/test/write.jl
@@ -83,7 +83,7 @@ test_write(@compat Dict(
 @test_throws ErrorException test_write(@compat Dict("yetanotherinvalidkeyyetanotherinvalidkeyyetanotherinvalidkeyyetanotherinvalidkey" => "too long"))
 
 type TestCompositeKind
-	field1::String
+	field1::AbstractString
 end
 fid = matopen(tmpfile, "w")
 write(fid, "test", TestCompositeKind("test value"))


### PR DESCRIPTION
Hello, 

I've updated the code to fix deprecation warnings about:
- `String` instead of `AbstractString`
- `None` instead of `Union{}`
- `Union(args...)` instead of Union{args...}`

Now the module import and tests run without warning for me on `0.5`. I also made sure `Pkg.test("MAT")` still works fine on `0.3`.

It would be great if we can get a tagged version after this to coincide with the `0.4` release.

Thanks,
Josh