### PR TITLE
Move include statements into module

### DIFF
--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -24,10 +24,14 @@
 
 VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
+module MAT
+
+using HDF5, Compat
+
 include("MAT_HDF5.jl")
 include("MAT_v5.jl")
-module MAT
-using HDF5, MAT_HDF5, MAT_v5, Compat
+
+using .MAT_HDF5, .MAT_v5
 
 export matopen, matread, matwrite, names, exists, @read, @write
 


### PR DESCRIPTION
In another module that was `using MAT`, when precompiling I was getting errors:
```jl
ERROR: LoadError: LoadError: ArgumentError: MAT_v5 not found in path
 in require at ./loading.jl:233
 in stale_cachefile at loading.jl:439
 in recompile_stale at loading.jl:457
 in _require_from_serialized at loading.jl:83
 in _require_from_serialized at ./loading.jl:109
 in require at ./loading.jl:219
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
```

I'm not exactly sure I understand why MAT was working before (and conversely why including it into my module didn't work), but things are working now that I moved the `include` statements inside the `module`. If nothing else, I don't think this should hurt anything.
