### PR TITLE
Fix depwarns

### DIFF
--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -27,6 +27,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 module MAT
 
 using HDF5, Compat
+using Compat.String
 
 include("MAT_HDF5.jl")
 include("MAT_v5.jl")

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -225,7 +225,7 @@ function m_read(g::HDF5Group)
     else
         fn = names(g)
     end
-    s = Dict{ASCIIString, Any}()
+    s = Dict{Compat.ASCIIString, Any}()
     for i = 1:length(fn)
         dset = g[fn[i]]
         try
@@ -237,7 +237,7 @@ function m_read(g::HDF5Group)
     s
 end
 
-function read(f::MatlabHDF5File, name::ASCIIString)
+function read(f::MatlabHDF5File, name::Compat.ASCIIString)
     local val
     obj = f.plain[name]
     try
@@ -249,7 +249,7 @@ function read(f::MatlabHDF5File, name::ASCIIString)
 end
 
 names(f::MatlabHDF5File) = filter!(x->x != "#refs#", names(f.plain))
-exists(p::MatlabHDF5File, path::ASCIIString) = exists(p.plain, path)
+exists(p::MatlabHDF5File, path::Compat.ASCIIString) = exists(p.plain, path)
 
 ### Writing
 
@@ -281,7 +281,7 @@ function m_writetypeattr(dset, T)
 end
 
 # Writes an empty scalar or array
-function m_writeempty(parent::HDF5Parent, name::ByteString, data::Array)
+function m_writeempty(parent::HDF5Parent, name::String, data::Array)
     adata = [size(data)...]
     dset, dtype = d_create(parent, name, adata)
     try
@@ -295,7 +295,7 @@ function m_writeempty(parent::HDF5Parent, name::ByteString, data::Array)
 end
 
 # Write an array to a dataset in a MATLAB file, returning the dataset
-function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::ByteString, adata::Array{T})
+function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::String, adata::Array{T})
     dset, dtype = d_create(parent, name, adata)
     try
         HDF5.writearray(dset, dtype.id, adata)
@@ -307,7 +307,7 @@ function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::ByteString, a
         close(dtype)
     end
 end
-function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::ByteString, adata::Array{Complex{T}})
+function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::String, adata::Array{Complex{T}})
     dtype = build_datatype_complex(T)
     try
         stype = dataspace(adata)
@@ -329,7 +329,7 @@ function m_writearray{T<:HDF5BitsOrBool}(parent::HDF5Parent, name::ByteString, a
 end
 
 # Write a scalar or array
-function m_write{T<:HDF5BitsOrBool}(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, data::@compat(Union{T, Complex{T}, Array{T}, Array{Complex{T}}}))
+function m_write{T<:HDF5BitsOrBool}(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, data::@compat(Union{T, Complex{T}, Array{T}, Array{Complex{T}}}))
     if isempty(data)
         m_writeempty(parent, name, data)
         return
@@ -343,7 +343,7 @@ function m_write{T<:HDF5BitsOrBool}(mfile::MatlabHDF5File, parent::HDF5Parent, n
 end
 
 # Write sparse arrays
-function m_write{T}(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, data::SparseMatrixCSC{T})
+function m_write{T}(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, data::SparseMatrixCSC{T})
     g = g_create(parent, name)
     try
         m_writetypeattr(g, T)
@@ -359,7 +359,7 @@ function m_write{T}(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString,
 end
 
 # Write a string
-function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, str::AbstractString)
+function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, str::AbstractString)
     if isempty(str)
         data = UInt64[0, 0]
 
@@ -396,7 +396,7 @@ function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, st
 end
 
 # Write cell arrays
-function m_write{T}(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, data::Array{T})
+function m_write{T}(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, data::Array{T})
     pathrefs = "/#refs#"
     fid = file(parent)
     local g
@@ -453,20 +453,20 @@ end
 
 # Check that keys are valid for a struct, and convert them to an array of ASCIIStrings
 function check_struct_keys(k::Vector)
-    asckeys = Array(ASCIIString, length(k))
+    asckeys = Array(Compat.ASCIIString, length(k))
     for i = 1:length(k)
         key = k[i]
         if !isa(key, AbstractString)
             error("Only Dicts with string keys may be saved as MATLAB structs")
         end
         check_valid_varname(key)
-        asckeys[i] = convert(ASCIIString, key)
+        asckeys[i] = convert(Compat.ASCIIString, key)
     end
     asckeys
 end
 
 # Write a struct from arrays of keys and values
-function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, k::Vector{ASCIIString}, v::Vector)
+function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, k::Vector{Compat.ASCIIString}, v::Vector)
     g = g_create(parent, name)
     a_write(g, name_type_attr_matlab, "struct")
     for i = 1:length(k)
@@ -476,11 +476,11 @@ function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, k:
 end
 
 # Write Associative as a struct
-m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, s::Associative) =
+m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, s::Associative) =
     m_write(mfile, parent, name, check_struct_keys(collect(keys(s))), collect(values(s)))
 
 # Write generic CompositeKind as a struct
-function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, s)
+function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, s)
     if isbits(s)
         error("This is the write function for CompositeKind, but the input doesn't fit")
     end
@@ -489,7 +489,7 @@ function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::ByteString, s)
 end
 
 # Check whether a variable name is valid, then write it
-function write(parent::MatlabHDF5File, name::ByteString, thing)
+function write(parent::MatlabHDF5File, name::String, thing)
     check_valid_varname(name)
     m_write(parent, parent.plain, name, thing)
 end
@@ -556,7 +556,7 @@ function read(obj::HDF5Object, ::Type{MatlabString})
     if ndims(data) == 1
         return utf8(convert(Vector{Char}, data))
     elseif ndims(data) == 2
-        return datap = ByteString[rstrip(utf8(convert(Vector{Char}, vec(data[i, :])))) for i = 1:size(data, 1)]
+        return datap = Compat.String[rstrip(utf8(convert(Vector{Char}, vec(data[i, :])))) for i = 1:size(data, 1)]
     else
         return data
     end

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -29,6 +29,8 @@
 module MAT_HDF5
 
 using HDF5, Compat
+using Compat.String
+
 import Base: read, write, close
 import HDF5: names, exists, HDF5ReferenceObj, HDF5BitsKind
 

--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -27,6 +27,7 @@
 
 module MAT_v5
 using Zlib, HDF5, Compat
+using Compat.String
 import Base: read, write, close
 import HDF5: names, exists
 
@@ -76,7 +77,7 @@ const CONVERT_TYPES = Type[
     @compat(Union{}), Float64, Float32, Int8, UInt8,
     Int16, UInt16, Int32, UInt32, Int64, UInt64]
 
-read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}) = 
+read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}) =
     swap_bytes ? bswap(read(f, T)) : read(f, T)
 function read_bswap{T}(f::IO, swap_bytes::Bool, ::Type{T}, dim::@compat(Union{Int, @compat Tuple{Vararg{Int}}}))
     d = read(f, T, dim)

--- a/test/read.jl
+++ b/test/read.jl
@@ -1,5 +1,6 @@
 using MAT, Base.Test
 using Compat
+using Compat.String
 
 function check(filename, result)
     matfile = matopen(filename)
@@ -119,7 +120,7 @@ for format in ["v6", "v7", "v7.3"]
         ]
     )
     check("logical.mat", result)
-    
+
     result = @compat Dict(
         "empty_cells" => Any[zeros(0, 0), "test", zeros(0, 0)].'
     )

--- a/test/read.jl
+++ b/test/read.jl
@@ -6,7 +6,7 @@ function check(filename, result)
     for (k, v) in result
         @test exists(matfile, k)
         got = read(matfile, k)
-        if !isequal(got, v) || (typeof(got) != typeof(v) && (!isa(got, ByteString) || !(isa(v, ByteString))))
+        if !isequal(got, v) || (typeof(got) != typeof(v) && (!isa(got, String) || !(isa(v, String))))
             close(matfile)
             error("""
                 Data mismatch reading $k from $filename ($format)
@@ -79,7 +79,7 @@ for format in ["v6", "v7", "v7.3"]
     result = @compat Dict(
         "simple_string" => "the quick brown fox",
         "accented_string" => "thé qüîck browñ fòx",
-        "concatenated_strings" => ByteString["this is a string", "this is another string"],
+        "concatenated_strings" => Compat.String["this is a string", "this is another string"],
         "cell_strings" => Any["this is a string" "this is another string"],
         "empty_string" => ""
     )
@@ -101,12 +101,12 @@ for format in ["v6", "v7", "v7.3"]
     check("cell.mat", result)
 
     result = @compat Dict(
-        "s" => Dict{ASCIIString,Any}(
+        "s" => Dict{Compat.ASCIIString,Any}(
             "a" => 1.0,
             "b" => [1.0 2.0],
             "c" => [1.0 2.0 3.0]
         ),
-        "s2" => Dict{ASCIIString,Any}("a" => Any[1.0 2.0])
+        "s2" => Dict{Compat.ASCIIString,Any}("a" => Any[1.0 2.0])
     )
     check("struct.mat", result)
 


### PR DESCRIPTION
I incorporated #55 and added a couple of `using Compat.String` lines to silence the (new) warnings on julia-0.4. If tests pass, I'll merge this myself.