### PR TITLE
Fix for UInt8 error in close()

### DIFF
--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -58,7 +58,7 @@ function close(f::MatlabHDF5File)
         if f.writeheader
             magic = zeros(UInt8, 512)
             identifier = "MATLAB 7.3 MAT-file" # minimal but sufficient
-            magic[1:length(identifier)] = Vector{UInt8}(identifier)
+            magic[1:length(identifier)] = Vector{UInt8}("$identifier")
             magic[126] = 0x02
             magic[127] = 0x49
             magic[128] = 0x4d


### PR DESCRIPTION
Fix for `UInt8` error when using `close()`:
```
ERROR: LoadError: LoadError: type String has no field data
Use `Vector{UInt8}(str)` instead.
Stacktrace:
 [1] close(::MAT.MAT_HDF5.MatlabHDF5File) at /home/vagrant/.julia/v0.6/MAT/src/MAT_HDF5.jl:61
```

cc: @yuyichao, @simonster, @syarra